### PR TITLE
Single table in insights

### DIFF
--- a/lib/dispatcher/dispatchers/custom-event.js
+++ b/lib/dispatcher/dispatchers/custom-event.js
@@ -3,12 +3,20 @@
 
 var transformMetric = require('../metric-transformer');
 
-module.exports = function (newrelic, prefixes) {
+module.exports = function (newrelic, prefixes,options) {
     var metricNames = require('../metric-name')(prefixes),
         dispatch = function (metricType, statsdKey, statsdValue) {
             var metricName = metricNames.customEventName(metricType, statsdKey),
                 metricValue = transformMetric.customEvent[metricType](statsdValue);
-            newrelic.recordCustomEvent(metricName, metricValue);
+            if (!options.customEvent.singleTable)
+                {
+                    newrelic.recordCustomEvent(metricName, metricValue);
+                }
+            else {
+                  metricValue['metricName'] = metricName
+                  var tableName = options.customEvent.tableName;
+                  newrelic.recordCustomEvent(tableName, metricValue);
+            }
         };
 
     return dispatch;

--- a/lib/dispatcher/dispatchers/custom-event.js
+++ b/lib/dispatcher/dispatchers/custom-event.js
@@ -3,21 +3,20 @@
 
 var transformMetric = require('../metric-transformer');
 
-module.exports = function (newrelic, prefixes,options) {
-    var metricNames = require('../metric-name')(prefixes),
-        dispatch = function (metricType, statsdKey, statsdValue) {
-            var metricName = metricNames.customEventName(metricType, statsdKey),
-                metricValue = transformMetric.customEvent[metricType](statsdValue);
-            if (!options.singleTable)
-                {
-                    newrelic.recordCustomEvent(metricName, metricValue);
-                }
-            else {
-                  metricValue['metricName'] = metricName
-                  var tableName = options.tableName;
-                  newrelic.recordCustomEvent(tableName, metricValue);
-            }
-        };
+module.exports = function(newrelic, prefixes, options) {
+  var metricNames = require('../metric-name')(prefixes),
+    dispatch = function(metricType, statsdKey, statsdValue) {
+      var metricName = metricNames.customEventName(metricType, statsdKey),
+        metricValue = transformMetric.customEvent[metricType](statsdValue);
+      if (!options.singleTable) {
+        newrelic.recordCustomEvent(metricName, metricValue);
+      } else {
+        metricValue['metricName'] = metricName;
+        metricName['instance_ip'] = options.machine_ip;
+        var tableName = options.tableName;
+        newrelic.recordCustomEvent(tableName, metricValue);
+      }
+    };
 
-    return dispatch;
+  return dispatch;
 };

--- a/lib/dispatcher/dispatchers/custom-event.js
+++ b/lib/dispatcher/dispatchers/custom-event.js
@@ -3,20 +3,22 @@
 
 var transformMetric = require('../metric-transformer');
 
-module.exports = function(newrelic, prefixes, options) {
-  var metricNames = require('../metric-name')(prefixes),
-    dispatch = function(metricType, statsdKey, statsdValue) {
-      var metricName = metricNames.customEventName(metricType, statsdKey),
-        metricValue = transformMetric.customEvent[metricType](statsdValue);
-      if (!options.singleTable) {
-        newrelic.recordCustomEvent(metricName, metricValue);
-      } else {
-        metricValue['metricName'] = metricName;
-        metricValue['instance_ip'] = options.machine_ip;
-        var tableName = options.tableName;
-        newrelic.recordCustomEvent(tableName, metricValue);
-      }
-    };
+module.exports = function (newrelic, prefixes, options) {
 
-  return dispatch;
+    var metricNames = require('../metric-name')(prefixes),
+        dispatch = function (metricType, statsdKey, statsdValue) {
+            var metricName = metricNames.customEventName(metricType, statsdKey),
+                metricValue = transformMetric.customEvent[metricType](statsdValue);
+
+            if (!options ||   !options.singleTable) {
+                newrelic.recordCustomEvent(metricName, metricValue);
+            } else {
+                metricValue.metricName = metricName;
+                metricValue.instance_ip = options.machine_ip;
+                console.log(metricValue);
+                newrelic.recordCustomEvent(options.tableName, metricValue);
+            }
+        };
+
+    return dispatch;
 };

--- a/lib/dispatcher/dispatchers/custom-event.js
+++ b/lib/dispatcher/dispatchers/custom-event.js
@@ -12,7 +12,7 @@ module.exports = function(newrelic, prefixes, options) {
         newrelic.recordCustomEvent(metricName, metricValue);
       } else {
         metricValue['metricName'] = metricName;
-        metricName['instance_ip'] = options.machine_ip;
+        metricValue['instance_ip'] = options.machine_ip;
         var tableName = options.tableName;
         newrelic.recordCustomEvent(tableName, metricValue);
       }

--- a/lib/dispatcher/dispatchers/custom-event.js
+++ b/lib/dispatcher/dispatchers/custom-event.js
@@ -8,13 +8,13 @@ module.exports = function (newrelic, prefixes,options) {
         dispatch = function (metricType, statsdKey, statsdValue) {
             var metricName = metricNames.customEventName(metricType, statsdKey),
                 metricValue = transformMetric.customEvent[metricType](statsdValue);
-            if (!options.customEvent.singleTable)
+            if (!options.singleTable)
                 {
                     newrelic.recordCustomEvent(metricName, metricValue);
                 }
             else {
                   metricValue['metricName'] = metricName
-                  var tableName = options.customEvent.tableName;
+                  var tableName = options.tableName;
                   newrelic.recordCustomEvent(tableName, metricValue);
             }
         };

--- a/lib/dispatcher/dispatchers/custom-metric.js
+++ b/lib/dispatcher/dispatchers/custom-metric.js
@@ -3,7 +3,7 @@
 
 var transformMetric = require('../metric-transformer');
 
-module.exports = function (newrelic, prefixes,options) {
+module.exports = function (newrelic, prefixes, options) {
 
     var metricNames = require('../metric-name')(prefixes),
         dispatch = function (metricType, statsdKey, statsdValue) {

--- a/lib/dispatcher/dispatchers/custom-metric.js
+++ b/lib/dispatcher/dispatchers/custom-metric.js
@@ -3,7 +3,7 @@
 
 var transformMetric = require('../metric-transformer');
 
-module.exports = function (newrelic, prefixes) {
+module.exports = function (newrelic, prefixes,options) {
 
     var metricNames = require('../metric-name')(prefixes),
         dispatch = function (metricType, statsdKey, statsdValue) {

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -1,10 +1,27 @@
 /*jslint unparam: true, node: true */
 'use strict';
 
-module.exports = function (newrelic, prefixes,options) {
-    var exports = {
-        customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes,options),
-        customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,options)
-    };
-    return exports;
+module.exports = function(newrelic, prefixes, options) {
+  var exports = {
+    var os = require('os');
+
+    var interfaces = os.networkInterfaces();
+    var addresses = [];
+    for (var k in interfaces) {
+      for (var k2 in interfaces[k]) {
+        var address = interfaces[k][k2];
+        if (address.family === 'IPv4' && !address.internal) {
+          addresses.push(address.address);
+        }
+      }
+    }
+    if (addresses.length > 0) {
+      options.machine_ip = addresses[0];
+    }
+    customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes,
+        options),
+      customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,
+        options)
+  };
+  return exports;
 };

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -1,27 +1,26 @@
 /*jslint unparam: true, node: true */
 'use strict';
+var os = require('os');
 
 module.exports = function(newrelic, prefixes, options) {
-  var exports = {
-    var os = require('os');
-
-    var interfaces = os.networkInterfaces();
-    var addresses = [];
-    for (var k in interfaces) {
-      for (var k2 in interfaces[k]) {
-        var address = interfaces[k][k2];
-        if (address.family === 'IPv4' && !address.internal) {
-          addresses.push(address.address);
-        }
+  var interfaces = os.networkInterfaces();
+  var addresses = [];
+  for (var k in interfaces) {
+    for (var k2 in interfaces[k]) {
+      var address = interfaces[k][k2];
+      if (address.family === 'IPv4' && !address.internal) {
+        addresses.push(address.address);
       }
     }
-    if (addresses.length > 0) {
-      options.machine_ip = addresses[0];
-    }
+  }
+  if (addresses.length > 0) {
+    options.machine_ip = addresses[0];
+  }
+  var exports = {
     customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes,
-        options),
-      customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,
-        options)
+      options),
+    customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,
+      options)
   };
   return exports;
 };

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -1,10 +1,10 @@
 /*jslint unparam: true, node: true */
 'use strict';
 
-module.exports = function (newrelic, prefixes) {
+module.exports = function (newrelic, prefixes,options) {
     var exports = {
-        customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes),
-        customEvent: require('./dispatchers/custom-event')(newrelic, prefixes)
+        customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes,options),
+        customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,options)
     };
     return exports;
 };

--- a/lib/dispatcher/index.js
+++ b/lib/dispatcher/index.js
@@ -2,25 +2,33 @@
 'use strict';
 var os = require('os');
 
-module.exports = function(newrelic, prefixes, options) {
-  var interfaces = os.networkInterfaces();
-  var addresses = [];
-  for (var k in interfaces) {
-    for (var k2 in interfaces[k]) {
-      var address = interfaces[k][k2];
-      if (address.family === 'IPv4' && !address.internal) {
-        addresses.push(address.address);
-      }
-    }
-  }
-  if (addresses.length > 0) {
-    options.machine_ip = addresses[0];
-  }
-  var exports = {
-    customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes,
-      options),
-    customEvent: require('./dispatchers/custom-event')(newrelic, prefixes,
-      options)
-  };
-  return exports;
+module.exports = function (newrelic, prefixes, options) {
+    options.machine_ip  = (function () {
+        var interfaces = os.networkInterfaces(), addresses = [], k, k2, address;
+        for (k in interfaces) {
+            if (interfaces.hasOwnProperty(k)) {
+                for (k2 in interfaces[k]) {
+                    if (interfaces[k].hasOwnProperty(k2)) {
+                        address = interfaces[k][k2];
+                        if (address.family === 'IPv4' && !address.internal) {
+                            addresses.push(address.address);
+                        }
+                    }
+                }
+            }
+        }
+        if (addresses.length > 0) {
+            address = addresses[0];
+        } else {
+            address = "null";
+        }
+        return address;
+    }());
+
+
+    var exports = {
+        customMetric: require('./dispatchers/custom-metric')(newrelic, prefixes, options),
+        customEvent: require('./dispatchers/custom-event')(newrelic, prefixes, options)
+    };
+    return exports;
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,11 @@ var options = {
         sets: 'Sets',
         counter_rates: 'Rates'
     }
+
+    customEvent:{
+      tableName: "statsd_new_relic_agent",
+      singleTable:false
+    }
 };
 
 /**
@@ -82,6 +87,7 @@ exports.init = function (startup_time, config, events, logger) {
 
     options.dispatchMetrics = config.dispatchMetrics || options.dispatchMetrics;
     options.dispatchers = config.dispatchers || options.dispatchers;
+    options.customEvent = config.customEvent || options.customEvent;
 
     /**
      * Global metric prefix option will override any other configured metric prefixes
@@ -110,7 +116,7 @@ exports.init = function (startup_time, config, events, logger) {
     }
 
     newrelic = require('newrelic');
-    dispatcher = require('./dispatcher')(newrelic, options.metricPrefix);
+    dispatcher = require('./dispatcher')(newrelic, options.metricPrefix,options.customEvent);
 
     events.on('flush', onFlush);
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ var options = {
         counters: 'Counters',
         sets: 'Sets',
         counter_rates: 'Rates'
-    }
+    },
 
     customEvent:{
       tableName: "statsd_new_relic_agent",

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,9 +32,9 @@ var options = {
         counter_rates: 'Rates'
     },
 
-    customEvent:{
-      tableName: "statsd_new_relic_agent",
-      singleTable:false
+    customEvent: {
+        tableName: "statsd_new_relic_agent",
+        singleTable: false
     }
 };
 
@@ -116,7 +116,7 @@ exports.init = function (startup_time, config, events, logger) {
     }
 
     newrelic = require('newrelic');
-    dispatcher = require('./dispatcher')(newrelic, options.metricPrefix,options.customEvent);
+    dispatcher = require('./dispatcher')(newrelic, options.metricPrefix, options.customEvent);
 
     events.on('flush', onFlush);
 

--- a/test/dispatcher/custom-event.test.js
+++ b/test/dispatcher/custom-event.test.js
@@ -13,7 +13,10 @@ var prefixes = {
 var newrelicSpy;
 var newrelic = { };
 
+var singleTableName = "T";
+var ipInstance = "127.0.0.1";
 var dispatchCustomEvent = require('../../lib/dispatcher/dispatchers/custom-event')(newrelic, prefixes);
+var dispatchCustomEventSingleTable = require('../../lib/dispatcher/dispatchers/custom-event')(newrelic, prefixes, {singleTable: true, tableName: singleTableName, machine_ip: ipInstance});
 
 describe('custom event dispatcher test', function () {
 
@@ -27,7 +30,19 @@ describe('custom event dispatcher test', function () {
             dispatchCustomEvent('counters', 'some.counter.key', 123);
             assert(newrelicSpy.calledOnce);
             assert(newrelicSpy.calledWith('Counters_some_counter_key', { eventValue: 123 }),
-                    'recordCustomEvent must be called');
+                'recordCustomEvent must be called');
+
+            done();
+        });
+    });
+
+
+    describe('when dispatching a counter custom event with single table', function () {
+        it('should call successfully new relic recordCustomEvent api', function (done) {
+            dispatchCustomEventSingleTable('counters', 'some.counter.key', 123);
+            assert(newrelicSpy.calledOnce);
+            assert(newrelicSpy.calledWith(singleTableName, { "eventValue": 123, "metricName": 'Counters_some_counter_key', "instance_ip": ipInstance}),
+                'recordCustomEvent must be called');
 
             done();
         });
@@ -43,6 +58,9 @@ describe('custom event dispatcher test', function () {
             done();
         });
     });
+
+
+
 
 
 });

--- a/test/dispatcher/custom-metric.test.js
+++ b/test/dispatcher/custom-metric.test.js
@@ -28,7 +28,6 @@ describe('custom metric dispatcher test', function () {
             assert(newrelicSpy.calledOnce);
             assert(newrelicSpy.calledWith('Custom/Counters/some.counter.key', 123),
                 'recordMetric must be called');
-
             done();
         });
     });


### PR DESCRIPTION
I wanted a way to concentrate my metrics in one table in insights.

After the merges the default custom events metrics should work as  before

I added the ability to add the following configurations:
  customEvent:{
     singleTable:true,
     tableName:"<Table name>"
   },

I also report the ip_address of the machine, so I will be able to drill down a specific machine 
